### PR TITLE
feat: implement POST /items (in memory) and tested using Postman

### DIFF
--- a/src/main/kotlin/Routing.kt
+++ b/src/main/kotlin/Routing.kt
@@ -1,16 +1,26 @@
 package com.mrx.inventory
 
 import com.mrx.inventory.models.HealthStatus
+import com.mrx.inventory.models.Item
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.request.receive
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+
+val inventory = mutableListOf<Item>()
 
 fun Application.configureRouting() {
     routing {
         get("/") {
             call.respond(HealthStatus("Household Inventory API is running"))
+        }
+        post("/items") {
+            val item = call.receive<Item>()
+            inventory.add(item)
+            call.respond(HttpStatusCode.Created, item)
         }
     }
 }

--- a/src/main/kotlin/Serialization.kt
+++ b/src/main/kotlin/Serialization.kt
@@ -12,10 +12,3 @@ fun Application.configureSerialization() {
         json()
     }
 }
-
-@Serializable
-data class Item(
-    val message: String,
-)
-
-

--- a/src/main/kotlin/models/Item.kt
+++ b/src/main/kotlin/models/Item.kt
@@ -3,6 +3,8 @@ package com.mrx.inventory.models
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HealthStatus(
-    val message: String
+data class Item(
+    val name: String,
+    val quantity: Int,
+    val unit: String,
 )


### PR DESCRIPTION
This PR adds the POST /items endpoint to the Household Inventory API.
Users can now send a JSON payload containing an item's name, quantity, and unit to add it to the in-memory inventory list.

Closes #1 